### PR TITLE
feat: add check boxes

### DIFF
--- a/components/DarkModeStyles.js
+++ b/components/DarkModeStyles.js
@@ -18,4 +18,9 @@ export const darkModeStyles = globalCss({
 	body: {
 		background: theme.colors.secondary,
 	},
+	html: {
+		"-webkit-font-smoothing": "antialiased",
+		textRendering: "optimizeLegibility",
+		textSizeAdjust: "100%",
+	},
 });

--- a/components/Layout/Components/Sidebar.js
+++ b/components/Layout/Components/Sidebar.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import Link from "next/link";
 import { styled } from "@washingtonpost/wpds-ui-kit";
 import Header from "../../Typography/Headers";
@@ -160,7 +160,6 @@ export default function Sidebar({ navigation }) {
 													>
 														<CustomLink
 															href={item.slug}
-															passHref
 															isCurrent={
 																router.asPath.includes(
 																	item.slug

--- a/components/Layout/Layout.js
+++ b/components/Layout/Layout.js
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
-import { Box, styled, theme } from "@washingtonpost/wpds-ui-kit";
-import * as Accordion from "@radix-ui/react-accordion";
+import { styled } from "@washingtonpost/wpds-ui-kit";
 import { NavigationBar } from "~/components/NavigationBar";
 import Sidebar from "~/components/Layout/Components/Sidebar";
 

--- a/components/Markdown/Components/Checkbox.js
+++ b/components/Markdown/Components/Checkbox.js
@@ -1,0 +1,78 @@
+import * as Checkbox from "@radix-ui/react-checkbox";
+import Check from "@washingtonpost/wpds-assets/asset/check";
+import {
+	Icon,
+	theme,
+	styled,
+	VisuallyHidden,
+} from "@washingtonpost/wpds-ui-kit";
+
+const StyledCheckbox = styled(Checkbox.Root, {
+	all: "unset",
+	backgroundColor: "$secondary",
+	width: "$100",
+	height: "$100",
+	borderRadius: "$012",
+	border: "1px solid $subtle",
+	verticalAlign: "middle",
+	display: "block",
+
+	"&[aria-checked='true']": {
+		backgroundColor: "$primary",
+		borderColor: "transparent",
+	},
+});
+
+const StyledIndicator = styled(Checkbox.Indicator, {
+	color: theme.colors.onPrimary,
+	lineHeight: "0",
+	width: "$100",
+	height: "$100",
+});
+
+const StyledCheck = styled(Check, {
+	variants: {
+		checked: {
+			true: {
+				visibility: "visible",
+			},
+			false: {
+				visibility: "hidden",
+			},
+		},
+	},
+
+	defaultVariant: {
+		checked: false,
+	},
+});
+
+export const InputCheckbox = (props) => {
+	return (
+		<StyledCheckbox {...props} id="c1">
+			{!props.checked && (
+				<StyledCheck
+					fill={theme.colors.onPrimary}
+					checked={props.checked}
+					css={{
+						// i have no idea why this is necessary
+						// in chrome latest version, the checkbox
+						// renders smaller in width than it should
+						width: "24px",
+					}}
+				/>
+			)}
+			<StyledIndicator>
+				<Icon size="16">
+					<StyledCheck
+						fill={theme.colors.onPrimary}
+						checked={props.checked}
+					/>
+				</Icon>
+			</StyledIndicator>
+			<VisuallyHidden htmlFor="c1">
+				{props.checked ? "checked" : "not checked"}
+			</VisuallyHidden>
+		</StyledCheckbox>
+	);
+};

--- a/components/Markdown/Components/Checkbox.js
+++ b/components/Markdown/Components/Checkbox.js
@@ -13,6 +13,7 @@ const StyledCheckbox = styled(Checkbox.Root, {
 	backgroundColor: "$secondary",
 	width: "$100",
 	height: "$100",
+	flex: "0 0 var(--base)",
 	borderRadius: "$012",
 	border: "1px solid $subtle",
 	verticalAlign: "middle",
@@ -26,12 +27,14 @@ const StyledCheckbox = styled(Checkbox.Root, {
 
 const StyledIndicator = styled(Checkbox.Indicator, {
 	color: theme.colors.onPrimary,
+	flex: "0 0 16px",
 	lineHeight: "0",
 	width: "$100",
 	height: "$100",
 });
 
 const StyledCheck = styled(Check, {
+	flex: "0 0 16px",
 	variants: {
 		checked: {
 			true: {
@@ -53,18 +56,6 @@ export const InputCheckbox = (props) => {
 
 	return (
 		<StyledCheckbox {...props} id={props.id || elementId}>
-			{!props.checked && (
-				<StyledCheck
-					fill={theme.colors.onPrimary}
-					checked={props.checked}
-					css={{
-						// i have no idea why this is necessary
-						// in chrome latest version, the checkbox
-						// renders smaller in width than it should
-						width: "24px",
-					}}
-				/>
-			)}
 			<StyledIndicator>
 				<Icon size="16">
 					<StyledCheck

--- a/components/Markdown/Components/Checkbox.js
+++ b/components/Markdown/Components/Checkbox.js
@@ -6,6 +6,7 @@ import {
 	styled,
 	VisuallyHidden,
 } from "@washingtonpost/wpds-ui-kit";
+import { useId } from "@react-aria/utils";
 
 const StyledCheckbox = styled(Checkbox.Root, {
 	all: "unset",
@@ -48,8 +49,10 @@ const StyledCheck = styled(Check, {
 });
 
 export const InputCheckbox = (props) => {
+	const elementId = useId();
+
 	return (
-		<StyledCheckbox {...props} id="c1">
+		<StyledCheckbox {...props} id={props.id || elementId}>
 			{!props.checked && (
 				<StyledCheck
 					fill={theme.colors.onPrimary}
@@ -70,7 +73,7 @@ export const InputCheckbox = (props) => {
 					/>
 				</Icon>
 			</StyledIndicator>
-			<VisuallyHidden htmlFor="c1">
+			<VisuallyHidden htmlFor={props.id || elementId}>
 				{props.checked ? "checked" : "not checked"}
 			</VisuallyHidden>
 		</StyledCheckbox>

--- a/components/Markdown/Components/EmbedStory.js
+++ b/components/Markdown/Components/EmbedStory.js
@@ -14,6 +14,7 @@ export default function EmbedStory({
 	const Story = styled("iframe", {
 		aspectRatio: "1 / 0.25",
 		width: "100%",
+		maxWidth: "100%",
 		borderRadius: "$025",
 		border: "$100 solid $subtle",
 		background: theme.colors["gray600-static"],

--- a/components/Markdown/Components/GuideContainer.js
+++ b/components/Markdown/Components/GuideContainer.js
@@ -1,0 +1,82 @@
+import React from "react";
+import { Icon, styled, theme, Box } from "@washingtonpost/wpds-ui-kit";
+import Success from "@washingtonpost/wpds-assets/asset/success";
+import Warning from "@washingtonpost/wpds-assets/asset/warning";
+import Info from "@washingtonpost/wpds-assets/asset/info";
+import Error from "@washingtonpost/wpds-assets/asset/error";
+
+const Div = styled("div", {
+	width: "100%",
+	padding: "$075 $075 $275",
+	backgroundColor: "$gray500",
+	color: "$gray80",
+	position: "relative",
+	display: "flex",
+	flexDirection: "column",
+	alignItems: "center",
+	justifyContent: "center",
+});
+
+const MessageContainer = styled("div", {
+	width: "100%",
+});
+
+const Message = styled("article", {
+	height: "$200",
+	padding: "$075 0",
+	display: "flex",
+	flexDirection: "row",
+	alignItems: "center",
+});
+
+const Rule = styled("hr", {
+	borderStyle: "solid",
+	borderWidth: "1px",
+	marginLeft: "$075",
+	width: "100%",
+	color: "transparent",
+
+	variants: {
+		variant: {
+			success: {
+				borderColor: "$success",
+			},
+			warning: {
+				borderColor: "$warning",
+			},
+			error: {
+				borderColor: "$error",
+			},
+			signal: {
+				borderColor: "$signal",
+			},
+		},
+	},
+});
+
+const Assets = {
+	success: Success,
+	warning: Warning,
+	signal: Info,
+	error: Error,
+};
+
+export default function GuideContainer({ variant, children }) {
+	const Asset = Assets[variant];
+
+	return (
+		<Div>
+			{variant && (
+				<MessageContainer>
+					<Message>
+						<Icon size="32">
+							<Asset fill={theme.colors[variant]} />
+						</Icon>
+						<Rule variant={variant} />
+					</Message>
+				</MessageContainer>
+			)}
+			{children}
+		</Div>
+	);
+}

--- a/components/Markdown/Components/Sandbox.js
+++ b/components/Markdown/Components/Sandbox.js
@@ -1,13 +1,13 @@
+import React from "react";
 import {
 	SandpackProvider,
 	SandpackLayout,
 	SandpackCodeEditor,
 	SandpackPreview,
-	SandpackCodeViewer,
 } from "@codesandbox/sandpack-react";
 import "@codesandbox/sandpack-react/dist/index.css";
 import { useTheme } from "next-themes";
-
+import { styled } from "@washingtonpost/wpds-ui-kit";
 const CustomSandpack = ({ withPreview, children }) => {
 	const { resolvedTheme } = useTheme();
 	return (
@@ -25,18 +25,17 @@ const CustomSandpack = ({ withPreview, children }) => {
 		>
 			<SandpackLayout theme={resolvedTheme}>
 				<SandpackCodeEditor
-					customStyle={{
-						height: "auto",
-						minHeight: "auto",
-					}}
-					wrapContent
+				// customStyle={{
+				// 	width: "100%",
+				// }}
+				// wrapContent
 				/>
 				{withPreview && (
 					<SandpackPreview
-						customStyle={{
-							height: "auto",
-							minHeight: "auto",
-						}}
+					// customStyle={{
+					// 	height: "auto",
+					// 	minHeight: "auto",
+					// }}
 					/>
 				)}
 			</SandpackLayout>
@@ -44,4 +43,4 @@ const CustomSandpack = ({ withPreview, children }) => {
 	);
 };
 
-export default CustomSandpack;
+export default React.memo(CustomSandpack);

--- a/components/Markdown/Components/headers.js
+++ b/components/Markdown/Components/headers.js
@@ -6,15 +6,20 @@ export const Header = styled("h1", {
 	fontSize: "$300",
 	fontFamily: "$headline",
 	color: "$primary",
+	fontWeight: "$bold",
 	variants: {
 		as: {
 			h2: {
+				fontFamily: "$headline",
 				fontSize: "$175",
+				fontWeight: "$bold",
+				lineHeight: "auto",
 			},
 			h3: {
 				fontSize: "$125",
 				fontFamily: "$subhead",
 				fontWeight: "$bold",
+				lineHeight: "auto",
 				marginBottom: "$025",
 				marginTop: "$100",
 			},
@@ -22,6 +27,7 @@ export const Header = styled("h1", {
 				fontSize: "$100",
 				fontWeight: "$bold",
 				fontFamily: "$meta",
+				lineHeight: "auto",
 			},
 			h6: {
 				fontSize: "$050",

--- a/components/Markdown/Components/list.js
+++ b/components/Markdown/Components/list.js
@@ -11,6 +11,16 @@ export const ListItem = styled("li", {
 		color: theme.colors.gray80,
 		textDecoration: "underline",
 	},
+	"&.task-list-item p": {
+		display: "flex",
+		alignItems: "flex-start",
+
+		"[role='checkbox']": {
+			marginBottom: "$025",
+			alignSelf: "flex-start",
+			marginRight: "$050",
+		},
+	},
 });
 export const LinkText = styled("span", {
 	color: "$accessible",

--- a/components/Markdown/Styling.js
+++ b/components/Markdown/Styling.js
@@ -21,6 +21,9 @@ export const P = styled("p", {
 	fontSize: "$100",
 	paddingBottom: "$050",
 	color: "$accessible",
+	fontFamily: "$meta",
+	fontWeight: "$light",
+	lineHeight: "auto",
 });
 
 export const BR = styled("div", {
@@ -61,6 +64,7 @@ const components = {
 	BR: BR,
 	TableOfContents: dynamic(() => import("./Components/tableofcontents")),
 	Container: dynamic(() => import("./Components/container")),
+	GuideContainer: dynamic(() => import("./Components/GuideContainer")),
 	Box: Box,
 	pre: ({ children }) => (
 		<Box

--- a/components/Markdown/Styling.js
+++ b/components/Markdown/Styling.js
@@ -5,14 +5,11 @@
 import Header from "./Components/headers";
 import CustomLink from "./Components/link";
 import { styled, Box } from "@washingtonpost/wpds-ui-kit";
-import {
-	List,
-	ListItem,
-	ListText,
-} from "~/components/Markdown/Components/list";
-// import TableOfContents from "./Components/tableofcontents";
+import { List, ListItem } from "~/components/Markdown/Components/list";
 import dynamic from "next/dynamic";
 import Sandbox from "./Components/Sandbox";
+import { InputCheckbox } from "./Components/Checkbox";
+
 const HR = styled("hr", {
 	borderStyle: "none",
 	backgroundColor: "$subtle",
@@ -65,11 +62,28 @@ const components = {
 	TableOfContents: dynamic(() => import("./Components/tableofcontents")),
 	Container: dynamic(() => import("./Components/container")),
 	Box: Box,
+	pre: ({ children }) => (
+		<Box
+			as="pre"
+			css={{
+				marginBottom: "$100",
+				overflowX: "auto",
+				"@sm": {
+					width: "calc(100vw - $100 - $100)",
+				},
+			}}
+		>
+			{children}
+		</Box>
+	),
 	code: ({ children }) => {
 		return (
 			<Box
+				as="code"
 				css={{
 					marginBottom: "$100",
+					maxWidth: "100%",
+					width: "100%",
 				}}
 			>
 				<Sandbox withPreview={children.includes("// preview")}>
@@ -84,6 +98,13 @@ const components = {
 				</Sandbox>
 			</Box>
 		);
+	},
+	input: ({ children, type, ...props }) => {
+		if (type === "checkbox") {
+			return <InputCheckbox {...props} />;
+		}
+
+		return <input {...props} />;
 	},
 };
 

--- a/components/Typography/Headers.js
+++ b/components/Typography/Headers.js
@@ -1,27 +1,3 @@
-import { styled } from "@washingtonpost/wpds-ui-kit";
-const Header = styled("h1", {
-	fontSize: "$300",
-	fontFamily: "$headline",
-	color: "$primary",
-	variants: {
-		as: {
-			h2: {
-				fontSize: "$175",
-			},
-			h3: {
-				fontSize: "$125",
-				fontFamily: "$subhead",
-				fontWeight: "$bold",
-				marginBottom: "$025",
-				marginTop: "$100",
-			},
-			h4: {
-				fontSize: "$100",
-				fontWeight: "$bold",
-				fontFamily: "$meta",
-			},
-		},
-	},
-});
+import { Header } from "../Markdown/Components/headers";
 
 export default Header;

--- a/mdx_components/visually-hidden.mdx
+++ b/mdx_components/visually-hidden.mdx
@@ -6,6 +6,14 @@ component: visually-hidden
 
 ---
 
+-   [x] Accessbility: Visual information required to identify components and states (except inactive components) has a contrast ratio to meet WCAG 2.0 level AA. This exclude text contrast requirements. Unless disabled text should always be accessbile.
+
+-   [x] States are defined: Includes all interactive states that are applicable (hover, down, focus, keyboard focus, disabled).
+
+-   [ ] Accessbility: Visual information required to identify components and states (except inactive components) has a contrast ratio to meet WCAG 2.0 level AA. This exclude text contrast requirements. Unless disabled text should always be accessbile.
+
+-   [ ] States are defined: Includes all interactive states that are applicable (hover, down, focus, keyboard focus, disabled).
+
 ## Anatomy
 
 <Container caption="The label is revealed when the window is in focus. This behavior is for integration/play purposes.">

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,8 @@
 			"dependencies": {
 				"@codesandbox/sandpack-react": "^0.10.11",
 				"@docsearch/react": "^3.0.0-alpha.42",
+				"@radix-ui/react-accordion": "^0.1.5",
+				"@radix-ui/react-checkbox": "^0.1.4",
 				"@uiw/react-codesandbox": "^1.1.4",
 				"@washingtonpost/site-components": "^6.4.2",
 				"@washingtonpost/wpds-assets": "1.1.13",
@@ -1639,6 +1641,229 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/popperjs"
+			}
+		},
+		"node_modules/@radix-ui/primitive": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-0.1.0.tgz",
+			"integrity": "sha512-tqxZKybwN5Fa3VzZry4G6mXAAb9aAqKmPtnVbZpL0vsBwvOHTBwsjHVPXylocYLwEtBY9SCe665bYnNB515uoA==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10"
+			}
+		},
+		"node_modules/@radix-ui/react-accordion": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-0.1.5.tgz",
+			"integrity": "sha512-NlI12e1R56/WwOjj255R4EjdSmtmpLvTFq1vpuF63r9uB7C3uzDpBBnupi6V1uGVE3zA8b0sy1US0OaqWpdyEA==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/primitive": "0.1.0",
+				"@radix-ui/react-collapsible": "0.1.5",
+				"@radix-ui/react-collection": "0.1.3",
+				"@radix-ui/react-compose-refs": "0.1.0",
+				"@radix-ui/react-context": "0.1.1",
+				"@radix-ui/react-id": "0.1.4",
+				"@radix-ui/react-primitive": "0.1.3",
+				"@radix-ui/react-use-controllable-state": "0.1.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0"
+			}
+		},
+		"node_modules/@radix-ui/react-checkbox": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-0.1.4.tgz",
+			"integrity": "sha512-UtiV0y4CNmcAdCqRaGGPxeET/asO44rfKxtBbMIxAD4BGPfSIe4+kkF0q624S5c7q07HXO0vhOYlSObR3Fj2bg==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/primitive": "0.1.0",
+				"@radix-ui/react-compose-refs": "0.1.0",
+				"@radix-ui/react-context": "0.1.1",
+				"@radix-ui/react-label": "0.1.4",
+				"@radix-ui/react-presence": "0.1.1",
+				"@radix-ui/react-primitive": "0.1.3",
+				"@radix-ui/react-use-controllable-state": "0.1.0",
+				"@radix-ui/react-use-previous": "0.1.0",
+				"@radix-ui/react-use-size": "0.1.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0"
+			}
+		},
+		"node_modules/@radix-ui/react-collapsible": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-0.1.5.tgz",
+			"integrity": "sha512-jhj0h+gGc04D04mQW1zJgBxMJecYV21XaeyghjyXtp+ObM4EHkXnfOA5MyRMzSNB4u8wQ6P1zGtAbxHz1A4Vvg==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/primitive": "0.1.0",
+				"@radix-ui/react-compose-refs": "0.1.0",
+				"@radix-ui/react-context": "0.1.1",
+				"@radix-ui/react-id": "0.1.4",
+				"@radix-ui/react-presence": "0.1.1",
+				"@radix-ui/react-primitive": "0.1.3",
+				"@radix-ui/react-use-controllable-state": "0.1.0",
+				"@radix-ui/react-use-layout-effect": "0.1.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0"
+			}
+		},
+		"node_modules/@radix-ui/react-collection": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-0.1.3.tgz",
+			"integrity": "sha512-tMBY65l87tj77fMX44EBjm5p8clR6swkcNFr0/dDVdEPC0Vf3fwkv62dezCnZyrRBpkOgZPDOp2kO73hYlCfXw==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/react-compose-refs": "0.1.0",
+				"@radix-ui/react-context": "0.1.1",
+				"@radix-ui/react-primitive": "0.1.3",
+				"@radix-ui/react-slot": "0.1.2"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0"
+			}
+		},
+		"node_modules/@radix-ui/react-compose-refs": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-0.1.0.tgz",
+			"integrity": "sha512-eyclbh+b77k+69Dk72q3694OHrn9B3QsoIRx7ywX341U9RK1ThgQjMFZoPtmZNQTksXHLNEiefR8hGVeFyInGg==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0"
+			}
+		},
+		"node_modules/@radix-ui/react-context": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-0.1.1.tgz",
+			"integrity": "sha512-PkyVX1JsLBioeu0jB9WvRpDBBLtLZohVDT3BB5CTSJqActma8S8030P57mWZb4baZifMvN7KKWPAA40UmWKkQg==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0"
+			}
+		},
+		"node_modules/@radix-ui/react-id": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-0.1.4.tgz",
+			"integrity": "sha512-/hq5m/D0ZfJWOS7TLF+G0l08KDRs87LBE46JkAvgKkg1fW4jkucx9At9D9vauIPSbdNmww5kXEp566hMlA8eXA==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/react-use-layout-effect": "0.1.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0"
+			}
+		},
+		"node_modules/@radix-ui/react-label": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-0.1.4.tgz",
+			"integrity": "sha512-I59IMdUhHixk6cG4D00UN+oFxTpur9cJQSOl+4EfSTJZs+x4PqDpM7p402/gb9sXJqylsUkDMHDdaPzLwPNf7g==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/react-compose-refs": "0.1.0",
+				"@radix-ui/react-context": "0.1.1",
+				"@radix-ui/react-id": "0.1.4",
+				"@radix-ui/react-primitive": "0.1.3"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0"
+			}
+		},
+		"node_modules/@radix-ui/react-presence": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-0.1.1.tgz",
+			"integrity": "sha512-LsL+NcWDpFUAYCmXeH02o4pgqcSLpwxP84UIjCtpIKrsPe2vLuhcp79KC/jZJeXz+of2lUpMAxpM+eCpxFZtlg==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/react-compose-refs": "0.1.0",
+				"@radix-ui/react-use-layout-effect": "0.1.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8"
+			}
+		},
+		"node_modules/@radix-ui/react-primitive": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-0.1.3.tgz",
+			"integrity": "sha512-fcyADaaAx2jdqEDLsTs6aX50S3L1c9K9CC6XMpJpuXFJCU4n9PGTFDZRtY2gAoXXoRCPIBsklCopSmGb6SsDjQ==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/react-slot": "0.1.2"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0"
+			}
+		},
+		"node_modules/@radix-ui/react-slot": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-0.1.2.tgz",
+			"integrity": "sha512-ADkqfL+agEzEguU3yS26jfB50hRrwf7U4VTwAOZEmi/g+ITcBWe12yM46ueS/UCIMI9Py+gFUaAdxgxafFvY2Q==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/react-compose-refs": "0.1.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0"
+			}
+		},
+		"node_modules/@radix-ui/react-use-callback-ref": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-0.1.0.tgz",
+			"integrity": "sha512-Va041McOFFl+aV+sejvl0BS2aeHx86ND9X/rVFmEFQKTXCp6xgUK0NGUAGcgBlIjnJSbMYPGEk1xKSSlVcN2Aw==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0"
+			}
+		},
+		"node_modules/@radix-ui/react-use-controllable-state": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-0.1.0.tgz",
+			"integrity": "sha512-zv7CX/PgsRl46a52Tl45TwqwVJdmqnlQEQhaYMz/yBOD2sx2gCkCFSoF/z9mpnYWmS6DTLNTg5lIps3fV6EnXg==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/react-use-callback-ref": "0.1.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0"
+			}
+		},
+		"node_modules/@radix-ui/react-use-layout-effect": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-0.1.0.tgz",
+			"integrity": "sha512-+wdeS51Y+E1q1Wmd+1xSSbesZkpVj4jsg0BojCbopWvgq5iBvixw5vgemscdh58ep98BwUbsFYnrywFhV9yrVg==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0"
+			}
+		},
+		"node_modules/@radix-ui/react-use-previous": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-0.1.0.tgz",
+			"integrity": "sha512-0fxNc33rYnCzDMPSiSnfS8YklnxQo8WqbAQXPAgIaaA1jRu2qFB916PL4qCIW+avcAAqFD38vWhqDqcVmBharA==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0"
+			}
+		},
+		"node_modules/@radix-ui/react-use-size": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-0.1.0.tgz",
+			"integrity": "sha512-TcZAsR+BYI46w/RbaSFCRACl+Jh6mDqhu6GS2r0iuJpIVrj8atff7qtTjmMmfGtEDNEjhl7DxN3pr1nTS/oruQ==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0"
 			}
 		},
 		"node_modules/@react-aria/button": {
@@ -19083,6 +19308,181 @@
 			"version": "2.11.2",
 			"resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.2.tgz",
 			"integrity": "sha512-92FRmppjjqz29VMJ2dn+xdyXZBrMlE42AV6Kq6BwjWV7CNUW1hs2FtxSNLQE+gJhaZ6AAmYuO9y8dshhcBl7vA=="
+		},
+		"@radix-ui/primitive": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-0.1.0.tgz",
+			"integrity": "sha512-tqxZKybwN5Fa3VzZry4G6mXAAb9aAqKmPtnVbZpL0vsBwvOHTBwsjHVPXylocYLwEtBY9SCe665bYnNB515uoA==",
+			"requires": {
+				"@babel/runtime": "^7.13.10"
+			}
+		},
+		"@radix-ui/react-accordion": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-0.1.5.tgz",
+			"integrity": "sha512-NlI12e1R56/WwOjj255R4EjdSmtmpLvTFq1vpuF63r9uB7C3uzDpBBnupi6V1uGVE3zA8b0sy1US0OaqWpdyEA==",
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/primitive": "0.1.0",
+				"@radix-ui/react-collapsible": "0.1.5",
+				"@radix-ui/react-collection": "0.1.3",
+				"@radix-ui/react-compose-refs": "0.1.0",
+				"@radix-ui/react-context": "0.1.1",
+				"@radix-ui/react-id": "0.1.4",
+				"@radix-ui/react-primitive": "0.1.3",
+				"@radix-ui/react-use-controllable-state": "0.1.0"
+			}
+		},
+		"@radix-ui/react-checkbox": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-0.1.4.tgz",
+			"integrity": "sha512-UtiV0y4CNmcAdCqRaGGPxeET/asO44rfKxtBbMIxAD4BGPfSIe4+kkF0q624S5c7q07HXO0vhOYlSObR3Fj2bg==",
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/primitive": "0.1.0",
+				"@radix-ui/react-compose-refs": "0.1.0",
+				"@radix-ui/react-context": "0.1.1",
+				"@radix-ui/react-label": "0.1.4",
+				"@radix-ui/react-presence": "0.1.1",
+				"@radix-ui/react-primitive": "0.1.3",
+				"@radix-ui/react-use-controllable-state": "0.1.0",
+				"@radix-ui/react-use-previous": "0.1.0",
+				"@radix-ui/react-use-size": "0.1.0"
+			}
+		},
+		"@radix-ui/react-collapsible": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-0.1.5.tgz",
+			"integrity": "sha512-jhj0h+gGc04D04mQW1zJgBxMJecYV21XaeyghjyXtp+ObM4EHkXnfOA5MyRMzSNB4u8wQ6P1zGtAbxHz1A4Vvg==",
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/primitive": "0.1.0",
+				"@radix-ui/react-compose-refs": "0.1.0",
+				"@radix-ui/react-context": "0.1.1",
+				"@radix-ui/react-id": "0.1.4",
+				"@radix-ui/react-presence": "0.1.1",
+				"@radix-ui/react-primitive": "0.1.3",
+				"@radix-ui/react-use-controllable-state": "0.1.0",
+				"@radix-ui/react-use-layout-effect": "0.1.0"
+			}
+		},
+		"@radix-ui/react-collection": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-0.1.3.tgz",
+			"integrity": "sha512-tMBY65l87tj77fMX44EBjm5p8clR6swkcNFr0/dDVdEPC0Vf3fwkv62dezCnZyrRBpkOgZPDOp2kO73hYlCfXw==",
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/react-compose-refs": "0.1.0",
+				"@radix-ui/react-context": "0.1.1",
+				"@radix-ui/react-primitive": "0.1.3",
+				"@radix-ui/react-slot": "0.1.2"
+			}
+		},
+		"@radix-ui/react-compose-refs": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-0.1.0.tgz",
+			"integrity": "sha512-eyclbh+b77k+69Dk72q3694OHrn9B3QsoIRx7ywX341U9RK1ThgQjMFZoPtmZNQTksXHLNEiefR8hGVeFyInGg==",
+			"requires": {
+				"@babel/runtime": "^7.13.10"
+			}
+		},
+		"@radix-ui/react-context": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-0.1.1.tgz",
+			"integrity": "sha512-PkyVX1JsLBioeu0jB9WvRpDBBLtLZohVDT3BB5CTSJqActma8S8030P57mWZb4baZifMvN7KKWPAA40UmWKkQg==",
+			"requires": {
+				"@babel/runtime": "^7.13.10"
+			}
+		},
+		"@radix-ui/react-id": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-0.1.4.tgz",
+			"integrity": "sha512-/hq5m/D0ZfJWOS7TLF+G0l08KDRs87LBE46JkAvgKkg1fW4jkucx9At9D9vauIPSbdNmww5kXEp566hMlA8eXA==",
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/react-use-layout-effect": "0.1.0"
+			}
+		},
+		"@radix-ui/react-label": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-0.1.4.tgz",
+			"integrity": "sha512-I59IMdUhHixk6cG4D00UN+oFxTpur9cJQSOl+4EfSTJZs+x4PqDpM7p402/gb9sXJqylsUkDMHDdaPzLwPNf7g==",
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/react-compose-refs": "0.1.0",
+				"@radix-ui/react-context": "0.1.1",
+				"@radix-ui/react-id": "0.1.4",
+				"@radix-ui/react-primitive": "0.1.3"
+			}
+		},
+		"@radix-ui/react-presence": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-0.1.1.tgz",
+			"integrity": "sha512-LsL+NcWDpFUAYCmXeH02o4pgqcSLpwxP84UIjCtpIKrsPe2vLuhcp79KC/jZJeXz+of2lUpMAxpM+eCpxFZtlg==",
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/react-compose-refs": "0.1.0",
+				"@radix-ui/react-use-layout-effect": "0.1.0"
+			}
+		},
+		"@radix-ui/react-primitive": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-0.1.3.tgz",
+			"integrity": "sha512-fcyADaaAx2jdqEDLsTs6aX50S3L1c9K9CC6XMpJpuXFJCU4n9PGTFDZRtY2gAoXXoRCPIBsklCopSmGb6SsDjQ==",
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/react-slot": "0.1.2"
+			}
+		},
+		"@radix-ui/react-slot": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-0.1.2.tgz",
+			"integrity": "sha512-ADkqfL+agEzEguU3yS26jfB50hRrwf7U4VTwAOZEmi/g+ITcBWe12yM46ueS/UCIMI9Py+gFUaAdxgxafFvY2Q==",
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/react-compose-refs": "0.1.0"
+			}
+		},
+		"@radix-ui/react-use-callback-ref": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-0.1.0.tgz",
+			"integrity": "sha512-Va041McOFFl+aV+sejvl0BS2aeHx86ND9X/rVFmEFQKTXCp6xgUK0NGUAGcgBlIjnJSbMYPGEk1xKSSlVcN2Aw==",
+			"requires": {
+				"@babel/runtime": "^7.13.10"
+			}
+		},
+		"@radix-ui/react-use-controllable-state": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-0.1.0.tgz",
+			"integrity": "sha512-zv7CX/PgsRl46a52Tl45TwqwVJdmqnlQEQhaYMz/yBOD2sx2gCkCFSoF/z9mpnYWmS6DTLNTg5lIps3fV6EnXg==",
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/react-use-callback-ref": "0.1.0"
+			}
+		},
+		"@radix-ui/react-use-layout-effect": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-0.1.0.tgz",
+			"integrity": "sha512-+wdeS51Y+E1q1Wmd+1xSSbesZkpVj4jsg0BojCbopWvgq5iBvixw5vgemscdh58ep98BwUbsFYnrywFhV9yrVg==",
+			"requires": {
+				"@babel/runtime": "^7.13.10"
+			}
+		},
+		"@radix-ui/react-use-previous": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-0.1.0.tgz",
+			"integrity": "sha512-0fxNc33rYnCzDMPSiSnfS8YklnxQo8WqbAQXPAgIaaA1jRu2qFB916PL4qCIW+avcAAqFD38vWhqDqcVmBharA==",
+			"requires": {
+				"@babel/runtime": "^7.13.10"
+			}
+		},
+		"@radix-ui/react-use-size": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-0.1.0.tgz",
+			"integrity": "sha512-TcZAsR+BYI46w/RbaSFCRACl+Jh6mDqhu6GS2r0iuJpIVrj8atff7qtTjmMmfGtEDNEjhl7DxN3pr1nTS/oruQ==",
+			"requires": {
+				"@babel/runtime": "^7.13.10"
+			}
 		},
 		"@react-aria/button": {
 			"version": "3.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 				"@docsearch/react": "^3.0.0-alpha.42",
 				"@radix-ui/react-accordion": "^0.1.5",
 				"@radix-ui/react-checkbox": "^0.1.4",
+				"@react-aria/ssr": "^3.1.0",
 				"@uiw/react-codesandbox": "^1.1.4",
 				"@washingtonpost/site-components": "^6.4.2",
 				"@washingtonpost/wpds-assets": "1.1.13",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 		"@docsearch/react": "^3.0.0-alpha.42",
 		"@radix-ui/react-accordion": "^0.1.5",
 		"@radix-ui/react-checkbox": "^0.1.4",
+		"@react-aria/ssr": "^3.1.0",
 		"@uiw/react-codesandbox": "^1.1.4",
 		"@washingtonpost/site-components": "^6.4.2",
 		"@washingtonpost/wpds-assets": "1.1.13",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 		"@codesandbox/sandpack-react": "^0.10.11",
 		"@docsearch/react": "^3.0.0-alpha.42",
 		"@radix-ui/react-accordion": "^0.1.5",
+		"@radix-ui/react-checkbox": "^0.1.4",
 		"@uiw/react-codesandbox": "^1.1.4",
 		"@washingtonpost/site-components": "^6.4.2",
 		"@washingtonpost/wpds-assets": "1.1.13",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,9 +1,9 @@
-import Head from "next/head";
 import { ThemeProvider } from "next-themes";
 import React from "react";
 import { globalStyles, darkTheme } from "@washingtonpost/wpds-ui-kit";
 import { darkModeStyles } from "~/components/DarkModeStyles";
 import { PageLayout } from "~/components/Layout";
+import { SSRProvider } from "@react-aria/ssr";
 
 function App({ Component, pageProps }) {
 	globalStyles();
@@ -16,6 +16,25 @@ function App({ Component, pageProps }) {
 
 	if (getLayout) {
 		return (
+			<SSRProvider>
+				<ThemeProvider
+					attribute="class"
+					defaultTheme="system"
+					value={{
+						dark: darkTheme.className,
+						light: "light",
+					}}
+					disableTransitionOnChange={false}
+					enableColorScheme={false}
+				>
+					{getLayout(<Component {...pageProps} />)}
+				</ThemeProvider>
+			</SSRProvider>
+		);
+	}
+
+	return (
+		<SSRProvider>
 			<ThemeProvider
 				attribute="class"
 				defaultTheme="system"
@@ -26,26 +45,11 @@ function App({ Component, pageProps }) {
 				disableTransitionOnChange={false}
 				enableColorScheme={false}
 			>
-				{getLayout(<Component {...pageProps} />)}
+				<PageLayout {...pageProps}>
+					<Component {...pageProps} />
+				</PageLayout>
 			</ThemeProvider>
-		);
-	}
-
-	return (
-		<ThemeProvider
-			attribute="class"
-			defaultTheme="system"
-			value={{
-				dark: darkTheme.className,
-				light: "light",
-			}}
-			disableTransitionOnChange={false}
-			enableColorScheme={false}
-		>
-			<PageLayout {...pageProps}>
-				<Component {...pageProps} />
-			</PageLayout>
-		</ThemeProvider>
+		</SSRProvider>
 	);
 }
 

--- a/pages/components/[slug].js
+++ b/pages/components/[slug].js
@@ -16,6 +16,7 @@ import { default as EmbedControls } from "~/components/Markdown/Components/Embed
 import { default as EmbedStory } from "~/components/Markdown/Components/EmbedStory";
 import { default as CustomSandpack } from "~/components/Markdown/Components/Sandbox";
 
+
 const components = {
 	...MDXStyling,
 	EmbedStory,

--- a/pages/test.js
+++ b/pages/test.js
@@ -1,0 +1,42 @@
+import * as React from "react";
+import { Box, styled } from "@washingtonpost/wpds-ui-kit";
+import GuideContainer from "~/components/Markdown/Components/GuideContainer";
+import Header from "~/components/Typography/Headers";
+
+const Stack = styled("div", {
+	display: "flex",
+	flexDirection: "column",
+	alignItems: "center",
+	justifyContent: "center",
+	width: "100%",
+	height: "100%",
+
+	"& > *": {
+		marginBottom: "$200",
+	},
+});
+
+export default function Page() {
+	return (
+		<Box>
+			<h1>Docs components</h1>
+			<Stack>
+				<GuideContainer>
+					<Header as="h3">Default</Header>
+				</GuideContainer>
+				<GuideContainer variant="success">
+					<Header as="h3">Success</Header>
+				</GuideContainer>
+				<GuideContainer variant="warning">
+					<Header as="h3">Warning</Header>
+				</GuideContainer>
+				<GuideContainer variant="signal">
+					<Header as="h3">Signal</Header>
+				</GuideContainer>
+				<GuideContainer variant="error">
+					<Header as="h3">Error</Header>
+				</GuideContainer>
+			</Stack>
+		</Box>
+	);
+}


### PR DESCRIPTION
- add check boxes. the "example copy" will be removed from visually-hidden after PR. maybe we need a playroom or storybook or kitchen sink page for the docs components
- fixes responsive issue with Sandbox components on mobile screen sizes
- adds GuideContainer to markdown styling
- adds a new /test page to have a place to test components https://wpds-docs-git-checkboxes.preview.now.washingtonpost.com/test