### PR TITLE
Switching all $accessible to types

### DIFF
--- a/components/Layout/Components/Sidebar.js
+++ b/components/Layout/Components/Sidebar.js
@@ -1,6 +1,6 @@
 import React from "react";
 import Link from "next/link";
-import { styled } from "@washingtonpost/wpds-ui-kit";
+import { styled, theme } from "@washingtonpost/wpds-ui-kit";
 import Header from "../../Typography/Headers";
 import * as Accordion from "@radix-ui/react-accordion";
 import ChevronDown from "@washingtonpost/wpds-assets/asset/chevron-down";
@@ -48,7 +48,7 @@ const AccordionHeader = styled(Header, {
 
 const AccordionChevron = styled(ChevronDown, {
 	height: 16,
-	fill: "$accessible",
+	fill: theme.colors.accessible,
 	justifySelf: "flex-end",
 	transition: "transform 300ms",
 	"[data-state=open] &": { transform: "rotate(180deg)" },
@@ -90,7 +90,7 @@ const CustomLink = styled("a", {
 	fontFamily: "$meta",
 	display: "block",
 	fontSize: "$100",
-	color: "$accessible",
+	color: theme.colors.accessible,
 	textDecoration: "none",
 	width: "100%",
 	borderLeft: "0 solid",

--- a/components/Markdown/Components/GuideContainer.js
+++ b/components/Markdown/Components/GuideContainer.js
@@ -9,7 +9,7 @@ const Div = styled("div", {
 	width: "100%",
 	padding: "$075 $075 $275",
 	backgroundColor: "$gray500",
-	color: "$accessbile",
+	color: theme.colors.accessible,
 	position: "relative",
 	display: "flex",
 	flexDirection: "column",

--- a/components/Markdown/Components/container.js
+++ b/components/Markdown/Components/container.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { styled } from "@washingtonpost/wpds-ui-kit";
+import { styled, theme } from "@washingtonpost/wpds-ui-kit";
 export default function Container({ children, caption }) {
 	const Div = styled("div", {
 		width: "100%",
@@ -8,10 +8,10 @@ export default function Container({ children, caption }) {
 		justifyContent: "center",
 		padding: "$275",
 		backgroundColor: "$gray500",
-		color: "$accessible",
+		color: theme.colors.accessible,
 	});
 	const Caption = styled("p", {
-		color: "$accessible",
+		color: theme.colors.accessible,
 		fontSize: "$087",
 		marginTop: "$050",
 	});

--- a/components/Markdown/Components/list.js
+++ b/components/Markdown/Components/list.js
@@ -31,7 +31,7 @@ export const ListItem = styled("li", {
 	},
 });
 export const LinkText = styled("span", {
-	color: "$accessible",
+	color: theme.colors.accessible,
 	textDecoration: "underline",
 	"&:focus": {
 		outlineColor: "$signal",

--- a/components/Markdown/Components/tableofcontents.jsx
+++ b/components/Markdown/Components/tableofcontents.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { styled } from "@washingtonpost/wpds-ui-kit";
+import { styled, theme } from "@washingtonpost/wpds-ui-kit";
 import Link from "next/link";
 import Header from "../../Typography/Headers";
 
@@ -18,7 +18,7 @@ const ListItem = styled("li", {
 	listStyle: "none",
 });
 const LinkText = styled("a", {
-	color: "$accessible",
+	color: theme.colors.accessible,
 	textDecoration: "underline",
 	"&:focus": {
 		outlineColor: "$signal",

--- a/components/Markdown/Components/tokenTable.js
+++ b/components/Markdown/Components/tokenTable.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { styled } from "@washingtonpost/wpds-ui-kit";
+import { styled, theme } from "@washingtonpost/wpds-ui-kit";
 import Tokens from "@washingtonpost/wpds-theme/src/wpds.tokens.json";
 
 export default function tokenTable({ headers, tableData }) {
@@ -21,7 +21,7 @@ export default function tokenTable({ headers, tableData }) {
 		width: "100%",
 	});
 	const TD = styled("td", {
-		color: "$accessible",
+		color: theme.colors.accessible,
 		border: "1px solid $subtle",
 		padding: "$050",
 		variants: {

--- a/components/Markdown/Styling.js
+++ b/components/Markdown/Styling.js
@@ -4,7 +4,7 @@
  */
 import Header from "./Components/headers";
 import CustomLink from "./Components/link";
-import { styled, Box } from "@washingtonpost/wpds-ui-kit";
+import { styled, theme, Box } from "@washingtonpost/wpds-ui-kit";
 import { List, ListItem } from "~/components/Markdown/Components/list";
 import dynamic from "next/dynamic";
 import Sandbox from "./Components/Sandbox";
@@ -20,7 +20,7 @@ const HR = styled("hr", {
 export const P = styled("p", {
 	fontSize: "$100",
 	paddingBottom: "$050",
-	color: "$accessible",
+	color: theme.colors.accessible,
 	fontFamily: "$meta",
 	fontWeight: "$light",
 });

--- a/components/logo.js
+++ b/components/logo.js
@@ -6,7 +6,7 @@ import Link from "next/link";
 const Container = styled("div", {
 	display: "flex",
 	alignItems: "center",
-	color: "$accessible",
+	color: theme.colors.accessible,
 	fontFamily: "$meta",
 	fontWeight: "$light",
 	cursor: "pointer",

--- a/components/versionButton.jsx
+++ b/components/versionButton.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { styled, keyframes } from "@washingtonpost/wpds-ui-kit";
+import { styled, theme, keyframes } from "@washingtonpost/wpds-ui-kit";
 import Link from "next/link";
 
 export default function VersionButton({ setState, css }) {
@@ -11,7 +11,7 @@ export default function VersionButton({ setState, css }) {
 	const Button = styled("button", {
 		fontFamily: "$meta",
 		fontSize: "$087",
-		color: "$accessible",
+		color: theme.colors.accessible,
 		backgroundColor: "transparent",
 		borderColor: "$gray200",
 		borderStyle: "solid",

--- a/mdx_blog/architecture/component-api.mdx
+++ b/mdx_blog/architecture/component-api.mdx
@@ -8,6 +8,6 @@ byline: By Arturo Silva and Brian Alfaro
 
 This is an example post, with a [link](https://nextjs.org) and a React component:
 
-The title and description are pulled from the MDX file and processed using `gray-matter`. Additionally, links are rendered using a custom component passed to `next-mdx-remote`.
+The title and description are pulled from the MDX file and processed using `gray-matter`; Additionally, links are rendered using a custom component passed to `next-mdx-remote`.
 
 Go back [home](/).

--- a/mdx_components/visually-hidden.mdx
+++ b/mdx_components/visually-hidden.mdx
@@ -6,11 +6,11 @@ component: visually-hidden
 
 ---
 
--   [x] Accessbility: Visual information required to identify components and states (except inactive components) has a contrast ratio to meet WCAG 2.0 level AA. This exclude text contrast requirements. Unless disabled text should always be accessbile.
+-   [x] Accessbility: Visual information required to identify components and states (except inactive components) has a contrast ratio to meet WCAG 2.0 level AA. This exclude text contrast requirements. Unless disabled text should always be accessible.
 
 -   [x] States are defined: Includes all interactive states that are applicable (hover, down, focus, keyboard focus, disabled).
 
--   [ ] Accessbility: Visual information required to identify components and states (except inactive components) has a contrast ratio to meet WCAG 2.0 level AA. This exclude text contrast requirements. Unless disabled text should always be accessbile.
+-   [ ] Accessbility: Visual information required to identify components and states (except inactive components) has a contrast ratio to meet WCAG 2.0 level AA. This exclude text contrast requirements. Unless disabled text should always be accessible.
 
 -   [ ] States are defined: Includes all interactive states that are applicable (hover, down, focus, keyboard focus, disabled).
 

--- a/mdx_foundations/color.mdx
+++ b/mdx_foundations/color.mdx
@@ -78,7 +78,7 @@ Use color to create an affordance to signal interaction, call to action, or a li
 
 #### Editorial tone
 
-Use color within the editorial palette to differentiate content with various lines of coverage.
+Color used within the editorial palette to differentiate content with various lines of coverage.
 
 <Container caption="The use of color to show something is live or an opinion">
 	<Box css={{ display: "flex", justifyContent: "center", margin: "auto" }}>

--- a/mdx_foundations/color.mdx
+++ b/mdx_foundations/color.mdx
@@ -183,7 +183,7 @@ abstraction that allows the system to strategically apply color across the produ
         Secondary
       </Box>
       <Box
-        css={{          
+        css={{
           padding:"$050",
           backgroundColor: "$cta",
           color: "$onCta"
@@ -244,7 +244,7 @@ abstraction that allows the system to strategically apply color across the produ
           color: "$onPrimary"
         }}
       >
-        Accessbile
+        Accessible
       </Box>
         <Box
         css={{
@@ -357,7 +357,7 @@ message around system status and actions taken by the user.
 ## Static
 
 Static colors are colors that do not change regardless of what theme context
-they are in (dark or light). These colors remain static to ensure they are accessbile
+they are in (dark or light). These colors remain static to ensure they are accessible
 when applied on a color where minimum contrast is required or branding requirements are applied. To use
 a static color simple add `-static` at the end of a color token name and it will lock the color in the light version of
 that color token.
@@ -367,7 +367,7 @@ that color token.
 #### Example
 
 Our theme token `onCta` and semantic color token `onMessage` both are tied to `gray-600-static`
-to ensure they remain with the correct minimal color contrast needed for the element to be accessbile.
+to ensure they remain with the correct minimal color contrast needed for the element to be accessible.
 
 <Container>
 	<Box css={{ display: "flex", justifyContent: "center", margin: "auto" }}>
@@ -402,10 +402,10 @@ contrast ratio outlined by WCAG 2.0 level AA.
 
 <BR />
 
-#### Accessbile
+#### Accessible
 
-One of our theme tokens named `accessbile` has been designed to ensure that no matter what
-theme you are using it will be the most accessbile color against the target background white or black. The color of this text you are reading is using our `accessbile` token.
+One of our theme tokens named `accessible` has been designed to ensure that no matter what
+theme you are using it will be the most accessible color against the target background white or black. The color of this text you are reading is using our `accessible` token.
 
 <Container>
 	<Box css={{ display: "flex", justifyContent: "center", margin: "auto" }}>
@@ -413,10 +413,10 @@ theme you are using it will be the most accessbile color against the target back
 			css={{
 				padding: "$300",
 				backgroundColor: "$gray600",
-				color: "$accessbile",
+				color: "$accessible",
 			}}
 		>
-			Accessbile color on target background
+			Accessible color on target background
 		</Box>
 	</Box>
 </Container>

--- a/mdx_foundations/color.mdx
+++ b/mdx_foundations/color.mdx
@@ -21,15 +21,14 @@ import Tokens from "@washingtonpost/wpds-theme/src/wpds.tokens.json";
 ### The role of color
 
 When we refer to color we exclude the entire grayscale. The use of color in our
-system is limited and it is intentional. Our product is highly focused on the content
-we want the reader experience to be with the minimal distraction of color variations,
-and when color is used in our system it comes with intention.
+system is limited and it is intentional. Our product focuses on the content
+and the reader experience. Color should always be a minimal distraction and used with intention.
 
 <BR size="xl" />
 
-#### Heirarchy and layout strucure
+#### Hierarchy and layout structure
 
-Utilizing color to separate sections of information and higlight elements of importance.
+Utilize color to separate sections of information and highlight elements of importance.
 
 <Container caption="Example of color to create layout structure">
 	<Box css={{ display: "flex", justifyContent: "center", margin: "auto" }}>
@@ -45,7 +44,7 @@ Utilizing color to separate sections of information and higlight elements of imp
 
 #### Affordance
 
-Utilizing color to separate sections of information and higlight elements of importance.
+Use color to create an affordance to signal interaction, call to action, or a link.
 
 <Container caption="Example of color to create layout structure">
 	<Box css={{ display: "flex", justifyContent: "center", margin: "auto" }}>
@@ -62,7 +61,7 @@ Utilizing color to separate sections of information and higlight elements of imp
 
 #### System status
 
-Elements change in color and make use of our `semantic colors` to represent default, success or failed states when completing an action or goal.
+`Semantic colors` represent system status of default, success, or failed states when completing an action or goal.
 
 <Container caption="Example of color to communicate system status">
 	<Box css={{ display: "flex", justifyContent: "center", margin: "auto" }}>
@@ -79,7 +78,7 @@ Elements change in color and make use of our `semantic colors` to represent defa
 
 #### Editorial tone
 
-Colors within the editorial palette are used to differentiate content with various lines of coverage.
+Use color within the editorial palette to differentiate content with various lines of coverage.
 
 <Container caption="The use of color to show something is live or an opinion">
 	<Box css={{ display: "flex", justifyContent: "center", margin: "auto" }}>
@@ -96,7 +95,7 @@ Colors within the editorial palette are used to differentiate content with vario
 
 #### Illustration
 
-Color is applied on illustrations and icons to achieve a visual style that varies across editorial tones, product functions and sub-brand art direction.
+Apply color to illustrations and icons to achieve a visual style that varies across editorial tones, product functions, and sub-brand art direction.
 
 <Container>
 	<Box css={{ display: "flex", justifyContent: "center", margin: "auto" }}>
@@ -113,7 +112,7 @@ Color is applied on illustrations and icons to achieve a visual style that varie
 
 #### Brand recognition
 
-An xl sub-brand has its own unique palette, art direction and visual look and feel to separate it from the WP brand.
+Sub-brands have a unique palette, art direction, visual look, and distinction from The Washington Post brand.
 
 <Container>
 	<Box css={{ display: "flex", justifyContent: "center", margin: "auto" }}>
@@ -149,9 +148,8 @@ Continuous and categorical datasets projected in a chart or map often require co
 
 ## Themes
 
-While our system has individual token colors available for use our system created a base
-theme that applies our color tokens to have intention in their usage. The theme is a level of
-abstraction that allows the system to strategically apply color across the product with intention.
+The theme palette is a level of abstraction that allows the system to assign color across the product with intention. It creates an alias and
+assigns a color intention.
 
 <Container>
   <div style={{ maxWidth: 600, margin: "auto" }}>
@@ -265,8 +263,8 @@ abstraction that allows the system to strategically apply color across the produ
 
 #### How to use theme
 
-Theme tokens are named with on are to be used with the pairing color token. Example onPrimary
-is used when an element or content is on the primary color token.
+Theme tokens with `on`(`onPrimary` or `onMessage`) in the name are paired with the base alias. One example is `onPrimary`
+is used when an element or content is on the `primary` color token.
 
 <Container>
 	<Box css={{ display: "flex", justifyContent: "center", margin: "auto" }}>
@@ -356,11 +354,10 @@ message around system status and actions taken by the user.
 
 ## Static
 
-Static colors are colors that do not change regardless of what theme context
+Static colors tokens that do not change value regardless of what theme context
 they are in (dark or light). These colors remain static to ensure they are accessible
 when applied on a color where minimum contrast is required or branding requirements are applied. To use
-a static color simple add `-static` at the end of a color token name and it will lock the color in the light version of
-that color token.
+a static color add `-static` at the end of a color token name and it will lock the color in the light value of that token.
 
 <BR />
 
@@ -404,8 +401,7 @@ contrast ratio outlined by WCAG 2.0 level AA.
 
 #### Accessible
 
-One of our theme tokens named `accessible` has been designed to ensure that no matter what
-theme you are using it will be the most accessible color against the target background white or black. The color of this text you are reading is using our `accessible` token.
+One of our theme tokens named `accessible` is accessible on the target background (`gray600` or `gray0`).
 
 <Container>
 	<Box css={{ display: "flex", justifyContent: "center", margin: "auto" }}>
@@ -428,8 +424,7 @@ theme you are using it will be the most accessible color against the target back
 ## Tokens
 
 All color tokens are calculated based on the base color and contrast of the target background
-theme (i.e. light or dark background). The result is the ability to design and assign color 1
-time and allow the pairing color value in dark to handle what an element should look like in dark.
+theme.
 
 ### Grays
 

--- a/pages/blog/[category]/[slug].js
+++ b/pages/blog/[category]/[slug].js
@@ -1,13 +1,13 @@
 import { MDXRemote } from "next-mdx-remote";
 import Head from "next/head";
-import { Box, styled } from "@washingtonpost/wpds-ui-kit";
+import { Box, theme, styled } from "@washingtonpost/wpds-ui-kit";
 import MDXStyling from "~/components/Markdown/Styling";
 import Header from "~/components/Typography/Headers";
 import { getNavigation, getAllPathsByCategory, getBlogPost } from "~/services";
 import CustomLink from "~/components/Typography/link";
 
 const Slash = styled("span", {
-	color: "$accessible",
+	color: theme.colors.accessible,
 });
 
 const SECTION = "blog";
@@ -47,7 +47,7 @@ export default function Page({ source }) {
 							fontWeight: "$light",
 
 							borderBottom: "1px solid currentColor",
-							color: "$accessible",
+							color: theme.colors.accessible,
 							marginRight: "$050",
 						}}
 					>
@@ -62,7 +62,7 @@ export default function Page({ source }) {
 							fontWeight: "$light",
 
 							borderBottom: "1px solid currentColor",
-							color: "$accessible",
+							color: theme.colors.accessible,
 							marginRight: "$050",
 							marginLeft: "$050",
 						}}

--- a/pages/blog/[category]/index.js
+++ b/pages/blog/[category]/index.js
@@ -1,4 +1,4 @@
-import { styled, Box } from "@washingtonpost/wpds-ui-kit";
+import { styled, theme, Box } from "@washingtonpost/wpds-ui-kit";
 import Head from "next/head";
 import Header from "~/components/Typography/Headers";
 import CustomLink from "~/components/Typography/link";
@@ -12,7 +12,7 @@ const titleCase = (input) => {
 };
 
 const Slash = styled("span", {
-	color: "$accessible",
+	color: theme.colors.accessible,
 });
 
 const Masonry = styled("section", {
@@ -44,7 +44,7 @@ export default function Page({ docs, category }) {
 						fontWeight: "$light",
 
 						borderBottom: "1px solid currentColor",
-						color: "$accessible",
+						color: theme.colors.accessible,
 						marginRight: "$050",
 						marginBottom: "$050",
 					}}

--- a/pages/blog/index.js
+++ b/pages/blog/index.js
@@ -1,7 +1,7 @@
 import React from "react";
 import Head from "next/head";
 import { getDocsListBySection, getNavigation } from "~/services";
-import { Box, Icon, styled } from "@washingtonpost/wpds-ui-kit";
+import { Box, Icon, theme, styled } from "@washingtonpost/wpds-ui-kit";
 import ChevronRight from "@washingtonpost/wpds-assets/asset/chevron-right";
 import { Header } from "~/components/Markdown/Components/headers";
 import Link from "~/components/Markdown/Components/link";
@@ -28,7 +28,7 @@ const Divider = styled("hr", {
 });
 
 const CheveronForLink = styled(ChevronRight, {
-	fill: "$accessible",
+	fill: theme.colors.accessible,
 });
 
 export default function Page({ docs, latestDocs, collections }) {

--- a/pages/components/[slug].js
+++ b/pages/components/[slug].js
@@ -1,6 +1,6 @@
 import { MDXRemote } from "next-mdx-remote";
 import Head from "next/head";
-import { styled } from "@washingtonpost/wpds-ui-kit";
+import { styled, theme } from "@washingtonpost/wpds-ui-kit";
 import MDXStyling from "~/components/Markdown/Styling";
 import Header from "~/components/Typography/Headers";
 import TableofContents from "~/components/Markdown/Components/tableofcontents";
@@ -16,7 +16,6 @@ import { default as EmbedControls } from "~/components/Markdown/Components/Embed
 import { default as EmbedStory } from "~/components/Markdown/Components/EmbedStory";
 import { default as CustomSandpack } from "~/components/Markdown/Components/Sandbox";
 
-
 const components = {
 	...MDXStyling,
 	EmbedStory,
@@ -27,7 +26,7 @@ const components = {
 };
 
 const P = styled("p", {
-	color: "$accessible",
+	color: theme.colors.accessible,
 });
 
 export default function Page({ current, source, headings }) {

--- a/pages/foundations/[slug].js
+++ b/pages/foundations/[slug].js
@@ -1,7 +1,7 @@
 import { MDXRemote } from "next-mdx-remote";
 import dynamic from "next/dynamic";
 import Head from "next/head";
-import { styled } from "@washingtonpost/wpds-ui-kit";
+import { styled, theme } from "@washingtonpost/wpds-ui-kit";
 import MDXStyling from "~/components/Markdown/Styling";
 import TokenTable from "~/components/Markdown/Components/tokenTable";
 import Header from "~/components/Typography/Headers";
@@ -16,7 +16,7 @@ const components = {
 	Head,
 };
 const P = styled("p", {
-	color: "$accessible",
+	color: theme.colors.accessible,
 });
 
 export default function Page({ source }) {

--- a/pages/foundations/assets.js
+++ b/pages/foundations/assets.js
@@ -66,7 +66,7 @@ const Grid = styled("section", {
 /** create a code example with a scrollbar */
 const CodeExample = styled("pre", {
 	overflow: "auto",
-	color: "$accessbile",
+	color: theme.colors.accessible,
 	fontSize: "$087",
 	lineHeight: "$125",
 });
@@ -118,7 +118,7 @@ const CopyToClipboard = ({ codeToCopy, children }) => {
 const P = styled("p", {
 	fontSize: "$100",
 	paddingBottom: "$050",
-	color: "$accessible",
+	color: theme.colors.accessible,
 });
 
 const codeSample = `import { theme, Icon, globalStyles } from "@washingtonpost/wpds-ui-kit";

--- a/pages/release-notes/[slug].js
+++ b/pages/release-notes/[slug].js
@@ -1,7 +1,7 @@
 import { MDXRemote } from "next-mdx-remote";
 import Head from "next/head";
 import MDXStyling from "~/components/Markdown/Styling";
-import { styled } from "@washingtonpost/wpds-ui-kit";
+import { styled, theme } from "@washingtonpost/wpds-ui-kit";
 import Header from "~/components/Typography/Headers";
 import { getDocByPathName, getAllPathsBySection } from "~/services";
 import { getNavigation } from "~/services/getNavigation";
@@ -24,7 +24,7 @@ const components = {
 const Description = styled("h2", {
 	fontSize: "$150",
 	lineHeight: "$150",
-	color: "$accessible",
+	color: theme.colors.accessible,
 	fontWeight: "normal",
 	marginBottom: "$100",
 });


### PR DESCRIPTION
Replaced all string `$accessible` tokens to type `theme.colors.accessible` also used grammarly on the color.mdx. 