### PR TITLE
docs: add note about using ui kit in nextjs

### DIFF
--- a/docs/resources/guides/react-guide.mdx
+++ b/docs/resources/guides/react-guide.mdx
@@ -18,7 +18,7 @@ npm install @stitches/react
 npm install @washingtonpost/wpds-ui-kit
 ```
 
-Let's configure the project to support Server Side Rendering. This is a requirement for the React UI Kit. We are following Stitches guide on how to do this. [Seen here.](https://stitches.dev/docs/server-side-rendering).
+Let's configure the project to support Server Side Rendering. This is a requirement for the React UI Kit in Next.js. We are following Stitches guide on how to do this. [Seen here.](https://stitches.dev/docs/server-side-rendering).
 
 ```jsx
 import React from "react";


### PR DESCRIPTION
I want to make it clear that uikit does not require SSR to work.