### PR TITLE
add rewrite rule for tachyons docs site

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -22,6 +22,16 @@ module.exports = withBundleAnalyzer({
       ],
       fallback: [
         {
+          source: "/tachyons",
+          destination:
+            "https://tachyons.preview.now.washingtonpost.com/tachyons",
+        },
+        {
+          source: "/tachyons/:slug*",
+          destination:
+            "https://tachyons.preview.now.washingtonpost.com/tachyons/:slug*",
+        },
+        {
           source: "/v0",
           destination: "https://v0.wpds.docs.preview.now.washingtonpost.com",
         },

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,14 @@
 {
   "rewrites": [
     {
+      "source": "/tachyons",
+      "destination": "https://tachyons.preview.now.washingtonpost.com/tachyons"
+    },
+    {
+      "source": "/tachyons/:slug*",
+      "destination": "https://tachyons.preview.now.washingtonpost.com/tachyons/:slug*"
+    },
+    {
       "source": "/v0",
       "destination": "https://v0.wpds.docs.preview.now.washingtonpost.com/"
     },


### PR DESCRIPTION
As part of our effort to [open source tachyons](https://github.com/WPMedia/wapo-tachyons-css). this is the thread about the topic https://washpost.slack.com/archives/C01FWHF12BG/p1648759033676509

we need a public url for their docs. the pathname will be https://build.washingtonpost.com/tachyons. open to ideas though

