### PR TITLE
feat: add prop desc to prop table

### DIFF
--- a/components/PropsTable.js
+++ b/components/PropsTable.js
@@ -51,67 +51,78 @@ export const PropsTable = ({ props }) => {
         <thead>
           <tr>
             <th>Prop</th>
+            <th>Description</th>
             <th>Type</th>
             <th>Default</th>
             <th>Required</th>
           </tr>
         </thead>
         <tbody>
-          {props.map(({ name, type, rawType = "", required, defaultValue }) => (
-            <Box
-              as="tr"
-              key={name}
-              css={{
-                verticalAlign: type === "enum" ? "top" : "middle",
-              }}
-            >
-              <td>{name}</td>
-              <Box as="td">
-                <Box
-                  css={
-                    type === "enum" && {
-                      display: "flex",
-                      flexDirection: "column",
-                      rowGap: "$050",
-                    }
-                  }
-                >
-                  <span>{type}</span>
+          {props.map(
+            ({
+              name,
+              description,
+              type,
+              rawType = "",
+              required,
+              defaultValue,
+            }) => (
+              <Box
+                as="tr"
+                key={name}
+                css={{
+                  verticalAlign: type === "enum" ? "top" : "middle",
+                }}
+              >
+                <td>{name}</td>
+                <td width="25%">{description}</td>
+                <Box as="td">
                   <Box
-                    css={{
-                      fontFamily: "$meta",
-                      fontSize: "$087",
-                      fontWeight: "$light",
-                      lineHeight: "$110",
-                      fontStyle: "italic",
-                    }}
+                    css={
+                      type === "enum" && {
+                        display: "flex",
+                        flexDirection: "column",
+                        rowGap: "$050",
+                      }
+                    }
                   >
-                    {type === "enum" ? rawType : ""}
+                    <span>{type}</span>
+                    <Box
+                      css={{
+                        fontFamily: "$meta",
+                        fontSize: "$087",
+                        fontWeight: "$light",
+                        lineHeight: "$110",
+                        fontStyle: "italic",
+                      }}
+                    >
+                      {type === "enum" ? rawType : ""}
+                    </Box>
                   </Box>
                 </Box>
+                <td>{defaultValue}</td>
+                <td>
+                  {required === "true" ? (
+                    <Box
+                      css={{
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "flex-start",
+                        columnGap: "calc($050 / 2)",
+                      }}
+                    >
+                      <Icon fill={theme.colors.success}>
+                        <Success />
+                      </Icon>
+                      True
+                    </Box>
+                  ) : (
+                    "False"
+                  )}
+                </td>
               </Box>
-              <td>{defaultValue}</td>
-              <td>
-                {required === "true" ? (
-                  <Box
-                    css={{
-                      display: "flex",
-                      alignItems: "center",
-                      justifyContent: "flex-start",
-                      columnGap: "calc($050 / 2)",
-                    }}
-                  >
-                    <Icon fill={theme.colors.success}>
-                      <Success />
-                    </Icon>
-                    True
-                  </Box>
-                ) : (
-                  "False"
-                )}
-              </td>
-            </Box>
-          ))}
+            )
+          )}
         </tbody>
       </Box>
     </Box>


### PR DESCRIPTION
https://arcpublishing.atlassian.net/browse/WPDS-1011

## testing instructions
1. visit component's prop table
2. description column should display
3. some not all props have descriptions thats ok
4. https://wpds-docs-git-prop-desc.preview.now.washingtonpost.com/components/input-password#API%20Reference