### PR TITLE
Buggies

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -83,6 +83,9 @@ const EditInGithub = styled("a", {
   "&:hover": {
     textDecoration: "underline",
   },
+  "@sm": {
+    marginLeft: "$100",
+  }
 });
 
 export const Footer = () => {

--- a/components/Footer.js
+++ b/components/Footer.js
@@ -85,7 +85,7 @@ const EditInGithub = styled("a", {
   },
   "@sm": {
     marginLeft: "$100",
-  }
+  },
 });
 
 export const Footer = () => {

--- a/docs/foundations/wam.mdx
+++ b/docs/foundations/wam.mdx
@@ -8,8 +8,8 @@ description: WPDS Asset-Manager (also known as WAM) manages all assets as raw SV
 
 - [Getting started](foundations/wam#Getting%20started)
 - [Design principles](/foundations/wam#Design%20principles)
-- [Grid and keyline shapes](/foundations/wam#Grid%20and%20keyline%20shapes)
-- [Icon Requests](/foundations/wam#Request)
+- [Icon design principles](/foundations/wam#Icon%20design%20principles)
+- [Icon requests](/foundations/wam#Request)
 - [Contributing](/foundations/wam#Contributing)
 
 ---


### PR DESCRIPTION
first bug with headings on WAM assets manager page (renamed one heading in TOC and made one lowercase to convention). Second bug with 'edit on github' footer on small screens, just added padding