### PR TITLE
fix: make footer width consistent with the rest of the body content

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -16,9 +16,11 @@ const StyledFooter = styled(SiteFooter, {
   "& > div.flex": {
     display: "grid",
     width: "100%",
+    maxWidth: "1028px",
     py: "$200",
     marginBottom: "$150",
     gridTemplateColumns: "repeat(4, 1fr)",
+    gap: "$100",
     borderTop: "1px solid $colors$subtle",
     borderBottom: "1px solid $colors$subtle",
   },


### PR DESCRIPTION
The PR sets the footer's max width to be consistent with the rest of the body content and adds a gap between the columns of links