### PR TITLE
docs: Update checkbox documentation

### DIFF
--- a/docs/components/checkbox.mdx
+++ b/docs/components/checkbox.mdx
@@ -256,14 +256,28 @@ export default function Example() {
           gap: "$025",
         }}
       >
-        <Checkbox checked={Check1} variant="primary" isOutline size="125" label="Category" id="cb1" />
+        <Checkbox
+          checked={Check1}
+          variant="primary"
+          isOutline
+          size="125"
+          label="Category"
+          id="cb1"
+        />
       </Box>
       <Box css={{ paddingLeft: "$100" }}>
         <Box
           onClick={() => setCheck2(!Check2)}
           css={{ cursor: "pointer", display: "flex", gap: "$025" }}
         >
-          <Checkbox checked={Check2} variant="primary" isOutline size="125" label="Option 1" id="cb2"/>
+          <Checkbox
+            checked={Check2}
+            variant="primary"
+            isOutline
+            size="125"
+            label="Option 1"
+            id="cb2"
+          />
         </Box>
         <Box
           onClick={() => setCheck3(!Check3)}
@@ -274,7 +288,14 @@ export default function Example() {
             gap: "$025",
           }}
         >
-          <Checkbox checked={Check3} variant="primary" isOutline size="125" label="Option 2" id="cb3"/>
+          <Checkbox
+            checked={Check3}
+            variant="primary"
+            isOutline
+            size="125"
+            label="Option 2"
+            id="cb3"
+          />
         </Box>
       </Box>
     </Box>
@@ -308,7 +329,14 @@ export default function Example() {
           gap: "$025",
         }}
       >
-        <Checkbox checked={Check1} variant="primary" isOutline size="125" label="Checkbox" id="cb4" />
+        <Checkbox
+          checked={Check1}
+          variant="primary"
+          isOutline
+          size="125"
+          label="Checkbox"
+          id="cb4"
+        />
       </Box>
     </Box>
   );

--- a/docs/components/checkbox.mdx
+++ b/docs/components/checkbox.mdx
@@ -254,19 +254,16 @@ export default function Example() {
           cursor: "pointer",
           display: "flex",
           gap: "$025",
-          fontWeight: "bold",
         }}
       >
-        <Checkbox checked={Check1} variant="primary" isOutline size="125" />
-        <label>Category</label>
+        <Checkbox checked={Check1} variant="primary" isOutline size="125" label="Category" id="cb1" />
       </Box>
       <Box css={{ paddingLeft: "$100" }}>
         <Box
           onClick={() => setCheck2(!Check2)}
           css={{ cursor: "pointer", display: "flex", gap: "$025" }}
         >
-          <Checkbox checked={Check2} variant="primary" isOutline size="125" />
-          <label>Option 1</label>
+          <Checkbox checked={Check2} variant="primary" isOutline size="125" label="Option 1" id="cb2"/>
         </Box>
         <Box
           onClick={() => setCheck3(!Check3)}
@@ -277,8 +274,7 @@ export default function Example() {
             gap: "$025",
           }}
         >
-          <Checkbox checked={Check3} variant="primary" isOutline size="125" />
-          <label>Option 2</label>
+          <Checkbox checked={Check3} variant="primary" isOutline size="125" label="Option 2" id="cb3"/>
         </Box>
       </Box>
     </Box>
@@ -312,8 +308,7 @@ export default function Example() {
           gap: "$025",
         }}
       >
-        <Checkbox checked={Check1} variant="primary" isOutline size="125" />
-        <label>Checkbox label</label>
+        <Checkbox checked={Check1} variant="primary" isOutline size="125" label="Checkbox" id="cb4" />
       </Box>
     </Box>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@washingtonpost/site-footer": "latest",
         "@washingtonpost/site-third-party-scripts": "latest",
         "@washingtonpost/wpds-assets": "v1.8.0",
-        "@washingtonpost/wpds-ui-kit": "v0.11.1",
+        "@washingtonpost/wpds-ui-kit": "^0.11.2",
         "gray-matter": "^4.0.2",
         "lz-string": "^1.4.4",
         "next": "^12.1.0",
@@ -4830,15 +4830,15 @@
       "license": "ISC"
     },
     "node_modules/@washingtonpost/wpds-alert-banner": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-alert-banner/-/wpds-alert-banner-0.11.1.tgz",
-      "integrity": "sha512-O0LhQS+jiXdoWsHJs9MkYP1JSgR44jMB/QWgyJzV2jrKodAoUl1DJB0g/2yjo78bXwLXjMT7scBYX9iVOwIONA==",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-alert-banner/-/wpds-alert-banner-0.11.2.tgz",
+      "integrity": "sha512-Ap1ECZW34eXXXUkJM/eabFZrFndLTveH/yyugI8/qWOfc4uQYOIysRanINsnggCqWTJZjc+6IeFUmMdf/T1o/w==",
       "dependencies": {
         "@washingtonpost/wpds-app-bar": "0.11.1",
         "@washingtonpost/wpds-assets": "^1.8.1",
-        "@washingtonpost/wpds-button": "0.11.1",
+        "@washingtonpost/wpds-button": "0.11.2",
         "@washingtonpost/wpds-container": "0.11.1",
-        "@washingtonpost/wpds-icon": "0.11.1",
+        "@washingtonpost/wpds-icon": "0.11.2",
         "@washingtonpost/wpds-theme": "0.11.1",
         "react": "^16.8.6 || ^17.0.2"
       },
@@ -4923,9 +4923,9 @@
       }
     },
     "node_modules/@washingtonpost/wpds-button": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-button/-/wpds-button-0.11.1.tgz",
-      "integrity": "sha512-hT1uNbE62bXwsPzrvm504HuD7IdzhhbBUTuyyGNe4t3KRBmtgmIwWILm/UT96BUu2/3YkOWJwmxB/5hqJazixA==",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-button/-/wpds-button-0.11.2.tgz",
+      "integrity": "sha512-5pXIrAeFmLe1ZmimY2bVQf+HQU8Ic2Y31nUNwXGr3S+Wb8F7fsy//cRyc2QUnYlamGS0UTeA5a7STwr0X8efOA==",
       "dependencies": {
         "@washingtonpost/wpds-theme": "0.11.1",
         "react": "^16.8.6 || ^17.0.2"
@@ -4936,15 +4936,15 @@
       }
     },
     "node_modules/@washingtonpost/wpds-checkbox": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-checkbox/-/wpds-checkbox-0.11.1.tgz",
-      "integrity": "sha512-3jyu2fGBp2c92Dl4JW3hzOm97TNpwpKqd8jjm5qMuq0YH5NbSzqn89SI4tCP09V5vi2LEGy3jjyA+S3/RT7EOg==",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-checkbox/-/wpds-checkbox-0.11.2.tgz",
+      "integrity": "sha512-U350FJiAiq20KMOS0U7Gdm/NhcgHV33Al/ObQNEqObVkmmWGQTA6nYOShpQyGZlCe3H0q5ayTMF/Pw77Telr3w==",
       "dependencies": {
         "@radix-ui/react-checkbox": "latest",
         "@washingtonpost/wpds-assets": "^1.8.1",
-        "@washingtonpost/wpds-icon": "0.11.1",
+        "@washingtonpost/wpds-icon": "0.11.2",
         "@washingtonpost/wpds-theme": "0.11.1",
-        "@washingtonpost/wpds-visually-hidden": "0.11.1",
+        "@washingtonpost/wpds-visually-hidden": "0.11.2",
         "react": "^16.8.6 || ^17.0.2"
       },
       "peerDependencies": {
@@ -5032,12 +5032,12 @@
       }
     },
     "node_modules/@washingtonpost/wpds-icon": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-icon/-/wpds-icon-0.11.1.tgz",
-      "integrity": "sha512-qiwSU2FCWzNj4KTffpkeIbUMs4plhpRnK696u1KqfX7GONwYhxeI4ZjvFji2J9x6pPuB0I2SgF1yTqDb7BnS+A==",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-icon/-/wpds-icon-0.11.2.tgz",
+      "integrity": "sha512-sXXoNq/f5OXofFKhUyVMhUaFb/+i/syraVsCDPaiZ4mT8zXC0FYIVLe8gEAomUDM7aN9nYYtQkq2Kmh004boAg==",
       "dependencies": {
         "@washingtonpost/wpds-theme": "0.11.1",
-        "@washingtonpost/wpds-visually-hidden": "0.11.1",
+        "@washingtonpost/wpds-visually-hidden": "0.11.2",
         "react": "^16.8.6 || ^17.0.2"
       },
       "peerDependencies": {
@@ -5060,13 +5060,13 @@
       }
     },
     "node_modules/@washingtonpost/wpds-input-password": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-input-password/-/wpds-input-password-0.11.1.tgz",
-      "integrity": "sha512-JhmMQb7mXRIGFK9p4rJU9ULQUhAvInwAS1mozpA8jOTf0ELwgPh/oOxhBqrt9zd1rQOfbTX1w7UbZ2yIsDpclw==",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-input-password/-/wpds-input-password-0.11.2.tgz",
+      "integrity": "sha512-9uqoR52Itps0DrX8ZB8PhRV9gET4ZAEcNbfJRQGOG/QnXia3luGinFYluyUrxd8HwY93qKAKQuDjAWALxCtEcQ==",
       "dependencies": {
         "@washingtonpost/wpds-assets": "*",
-        "@washingtonpost/wpds-icon": "0.11.1",
-        "@washingtonpost/wpds-input-text": "0.11.1"
+        "@washingtonpost/wpds-icon": "0.11.2",
+        "@washingtonpost/wpds-input-text": "0.11.2"
       },
       "peerDependencies": {
         "@washingtonpost/wpds-assets": "*",
@@ -5088,21 +5088,21 @@
       }
     },
     "node_modules/@washingtonpost/wpds-input-text": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-input-text/-/wpds-input-text-0.11.1.tgz",
-      "integrity": "sha512-ym0QLTOzHS5/KceU091tbm814uxHli8Oen/QKjA0SucdjUzCCzUFOvFRZVU2WGN5n2cG4BO7Rg+o0p7KRvvoJw==",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-input-text/-/wpds-input-text-0.11.2.tgz",
+      "integrity": "sha512-QluFM6bgfRZv70yURayO5DYtY+49Rrl02dIcdu08Q1ep1kzF6ewona40fJDMgNc5gps5gRLnvqEodFKS2utjaQ==",
       "dependencies": {
         "@radix-ui/react-label": "^0.1.5",
         "@washingtonpost/wpds-assets": "*",
         "@washingtonpost/wpds-box": "0.11.1",
-        "@washingtonpost/wpds-button": "0.11.1",
+        "@washingtonpost/wpds-button": "0.11.2",
         "@washingtonpost/wpds-error-message": "0.11.1",
         "@washingtonpost/wpds-helper-text": "0.11.1",
-        "@washingtonpost/wpds-icon": "0.11.1",
+        "@washingtonpost/wpds-icon": "0.11.2",
         "@washingtonpost/wpds-input-label": "0.11.1",
         "@washingtonpost/wpds-input-shared": "0.11.1",
         "@washingtonpost/wpds-theme": "0.11.1",
-        "@washingtonpost/wpds-visually-hidden": "0.11.1",
+        "@washingtonpost/wpds-visually-hidden": "0.11.2",
         "nanoid": "^3.3.2"
       },
       "peerDependencies": {
@@ -5172,31 +5172,31 @@
       }
     },
     "node_modules/@washingtonpost/wpds-ui-kit": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-ui-kit/-/wpds-ui-kit-0.11.1.tgz",
-      "integrity": "sha512-Rf83cIj2B8GbapnA+VHOgvIsEfGS33Gk9h6DQfWBxx7KwoUq4fl+58qGotlKBON8Wg0aHcvhJxxqZXhZFv8gAQ==",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-ui-kit/-/wpds-ui-kit-0.11.2.tgz",
+      "integrity": "sha512-TMQ1vAvVtyjYQIsLTn0xYMwq8JCgF8tt9AufPuf/m5cwR8o0fi3LphEyGDutujn/A/vBAfhdcLtl6BwvQktvGA==",
       "dependencies": {
         "@washingtonpost/eslint-plugin-wpds": "0.11.1",
-        "@washingtonpost/wpds-alert-banner": "0.11.1",
+        "@washingtonpost/wpds-alert-banner": "0.11.2",
         "@washingtonpost/wpds-app-bar": "0.11.1",
         "@washingtonpost/wpds-avatar": "0.11.1",
         "@washingtonpost/wpds-box": "0.11.1",
-        "@washingtonpost/wpds-button": "0.11.1",
-        "@washingtonpost/wpds-checkbox": "0.11.1",
+        "@washingtonpost/wpds-button": "0.11.2",
+        "@washingtonpost/wpds-checkbox": "0.11.2",
         "@washingtonpost/wpds-container": "0.11.1",
         "@washingtonpost/wpds-divider": "0.11.1",
         "@washingtonpost/wpds-error-message": "0.11.1",
         "@washingtonpost/wpds-fieldset": "0.11.1",
         "@washingtonpost/wpds-helper-text": "0.11.1",
-        "@washingtonpost/wpds-icon": "0.11.1",
+        "@washingtonpost/wpds-icon": "0.11.2",
         "@washingtonpost/wpds-input-label": "0.11.1",
-        "@washingtonpost/wpds-input-password": "0.11.1",
+        "@washingtonpost/wpds-input-password": "0.11.2",
         "@washingtonpost/wpds-input-shared": "0.11.1",
-        "@washingtonpost/wpds-input-text": "0.11.1",
+        "@washingtonpost/wpds-input-text": "0.11.2",
         "@washingtonpost/wpds-input-textarea": "0.11.1",
         "@washingtonpost/wpds-radio-group": "0.11.1",
         "@washingtonpost/wpds-theme": "0.11.1",
-        "@washingtonpost/wpds-visually-hidden": "0.11.1"
+        "@washingtonpost/wpds-visually-hidden": "0.11.2"
       },
       "peerDependencies": {
         "@washingtonpost/eslint-plugin-wpds": "*",
@@ -5223,9 +5223,9 @@
       }
     },
     "node_modules/@washingtonpost/wpds-visually-hidden": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-visually-hidden/-/wpds-visually-hidden-0.11.1.tgz",
-      "integrity": "sha512-f9+ShTsNZzTgCRhXAIgUQOBmozLR6p+xZF/FE+cOSUwoby7cMNtYWIPhqaF+ymAExUti+9Lr3xWH0w2ZOn4how==",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-visually-hidden/-/wpds-visually-hidden-0.11.2.tgz",
+      "integrity": "sha512-F/zdws5xHp9e7whwfVuAEqqWU0MD3JPTXEsTF/pNQ+aEIHA1ZBblr2C8MxGNMoVn/OIxcizVMjiYxGN5pMWEkw==",
       "dependencies": {
         "@washingtonpost/wpds-theme": "0.11.1",
         "react": "^16.8.6 || ^17.0.2"
@@ -16768,15 +16768,15 @@
       "version": "0.6.0"
     },
     "@washingtonpost/wpds-alert-banner": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-alert-banner/-/wpds-alert-banner-0.11.1.tgz",
-      "integrity": "sha512-O0LhQS+jiXdoWsHJs9MkYP1JSgR44jMB/QWgyJzV2jrKodAoUl1DJB0g/2yjo78bXwLXjMT7scBYX9iVOwIONA==",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-alert-banner/-/wpds-alert-banner-0.11.2.tgz",
+      "integrity": "sha512-Ap1ECZW34eXXXUkJM/eabFZrFndLTveH/yyugI8/qWOfc4uQYOIysRanINsnggCqWTJZjc+6IeFUmMdf/T1o/w==",
       "requires": {
         "@washingtonpost/wpds-app-bar": "0.11.1",
         "@washingtonpost/wpds-assets": "^1.8.1",
-        "@washingtonpost/wpds-button": "0.11.1",
+        "@washingtonpost/wpds-button": "0.11.2",
         "@washingtonpost/wpds-container": "0.11.1",
-        "@washingtonpost/wpds-icon": "0.11.1",
+        "@washingtonpost/wpds-icon": "0.11.2",
         "@washingtonpost/wpds-theme": "0.11.1",
         "react": "^16.8.6 || ^17.0.2"
       },
@@ -16829,24 +16829,24 @@
       }
     },
     "@washingtonpost/wpds-button": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-button/-/wpds-button-0.11.1.tgz",
-      "integrity": "sha512-hT1uNbE62bXwsPzrvm504HuD7IdzhhbBUTuyyGNe4t3KRBmtgmIwWILm/UT96BUu2/3YkOWJwmxB/5hqJazixA==",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-button/-/wpds-button-0.11.2.tgz",
+      "integrity": "sha512-5pXIrAeFmLe1ZmimY2bVQf+HQU8Ic2Y31nUNwXGr3S+Wb8F7fsy//cRyc2QUnYlamGS0UTeA5a7STwr0X8efOA==",
       "requires": {
         "@washingtonpost/wpds-theme": "0.11.1",
         "react": "^16.8.6 || ^17.0.2"
       }
     },
     "@washingtonpost/wpds-checkbox": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-checkbox/-/wpds-checkbox-0.11.1.tgz",
-      "integrity": "sha512-3jyu2fGBp2c92Dl4JW3hzOm97TNpwpKqd8jjm5qMuq0YH5NbSzqn89SI4tCP09V5vi2LEGy3jjyA+S3/RT7EOg==",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-checkbox/-/wpds-checkbox-0.11.2.tgz",
+      "integrity": "sha512-U350FJiAiq20KMOS0U7Gdm/NhcgHV33Al/ObQNEqObVkmmWGQTA6nYOShpQyGZlCe3H0q5ayTMF/Pw77Telr3w==",
       "requires": {
         "@radix-ui/react-checkbox": "latest",
         "@washingtonpost/wpds-assets": "^1.8.1",
-        "@washingtonpost/wpds-icon": "0.11.1",
+        "@washingtonpost/wpds-icon": "0.11.2",
         "@washingtonpost/wpds-theme": "0.11.1",
-        "@washingtonpost/wpds-visually-hidden": "0.11.1",
+        "@washingtonpost/wpds-visually-hidden": "0.11.2",
         "react": "^16.8.6 || ^17.0.2"
       },
       "dependencies": {
@@ -16904,12 +16904,12 @@
       }
     },
     "@washingtonpost/wpds-icon": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-icon/-/wpds-icon-0.11.1.tgz",
-      "integrity": "sha512-qiwSU2FCWzNj4KTffpkeIbUMs4plhpRnK696u1KqfX7GONwYhxeI4ZjvFji2J9x6pPuB0I2SgF1yTqDb7BnS+A==",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-icon/-/wpds-icon-0.11.2.tgz",
+      "integrity": "sha512-sXXoNq/f5OXofFKhUyVMhUaFb/+i/syraVsCDPaiZ4mT8zXC0FYIVLe8gEAomUDM7aN9nYYtQkq2Kmh004boAg==",
       "requires": {
         "@washingtonpost/wpds-theme": "0.11.1",
-        "@washingtonpost/wpds-visually-hidden": "0.11.1",
+        "@washingtonpost/wpds-visually-hidden": "0.11.2",
         "react": "^16.8.6 || ^17.0.2"
       }
     },
@@ -16923,13 +16923,13 @@
       }
     },
     "@washingtonpost/wpds-input-password": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-input-password/-/wpds-input-password-0.11.1.tgz",
-      "integrity": "sha512-JhmMQb7mXRIGFK9p4rJU9ULQUhAvInwAS1mozpA8jOTf0ELwgPh/oOxhBqrt9zd1rQOfbTX1w7UbZ2yIsDpclw==",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-input-password/-/wpds-input-password-0.11.2.tgz",
+      "integrity": "sha512-9uqoR52Itps0DrX8ZB8PhRV9gET4ZAEcNbfJRQGOG/QnXia3luGinFYluyUrxd8HwY93qKAKQuDjAWALxCtEcQ==",
       "requires": {
         "@washingtonpost/wpds-assets": "*",
-        "@washingtonpost/wpds-icon": "0.11.1",
-        "@washingtonpost/wpds-input-text": "0.11.1"
+        "@washingtonpost/wpds-icon": "0.11.2",
+        "@washingtonpost/wpds-input-text": "0.11.2"
       }
     },
     "@washingtonpost/wpds-input-shared": {
@@ -16941,21 +16941,21 @@
       }
     },
     "@washingtonpost/wpds-input-text": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-input-text/-/wpds-input-text-0.11.1.tgz",
-      "integrity": "sha512-ym0QLTOzHS5/KceU091tbm814uxHli8Oen/QKjA0SucdjUzCCzUFOvFRZVU2WGN5n2cG4BO7Rg+o0p7KRvvoJw==",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-input-text/-/wpds-input-text-0.11.2.tgz",
+      "integrity": "sha512-QluFM6bgfRZv70yURayO5DYtY+49Rrl02dIcdu08Q1ep1kzF6ewona40fJDMgNc5gps5gRLnvqEodFKS2utjaQ==",
       "requires": {
         "@radix-ui/react-label": "^0.1.5",
         "@washingtonpost/wpds-assets": "*",
         "@washingtonpost/wpds-box": "0.11.1",
-        "@washingtonpost/wpds-button": "0.11.1",
+        "@washingtonpost/wpds-button": "0.11.2",
         "@washingtonpost/wpds-error-message": "0.11.1",
         "@washingtonpost/wpds-helper-text": "0.11.1",
-        "@washingtonpost/wpds-icon": "0.11.1",
+        "@washingtonpost/wpds-icon": "0.11.2",
         "@washingtonpost/wpds-input-label": "0.11.1",
         "@washingtonpost/wpds-input-shared": "0.11.1",
         "@washingtonpost/wpds-theme": "0.11.1",
-        "@washingtonpost/wpds-visually-hidden": "0.11.1",
+        "@washingtonpost/wpds-visually-hidden": "0.11.2",
         "nanoid": "^3.3.2"
       }
     },
@@ -16994,37 +16994,37 @@
       }
     },
     "@washingtonpost/wpds-ui-kit": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-ui-kit/-/wpds-ui-kit-0.11.1.tgz",
-      "integrity": "sha512-Rf83cIj2B8GbapnA+VHOgvIsEfGS33Gk9h6DQfWBxx7KwoUq4fl+58qGotlKBON8Wg0aHcvhJxxqZXhZFv8gAQ==",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-ui-kit/-/wpds-ui-kit-0.11.2.tgz",
+      "integrity": "sha512-TMQ1vAvVtyjYQIsLTn0xYMwq8JCgF8tt9AufPuf/m5cwR8o0fi3LphEyGDutujn/A/vBAfhdcLtl6BwvQktvGA==",
       "requires": {
         "@washingtonpost/eslint-plugin-wpds": "0.11.1",
-        "@washingtonpost/wpds-alert-banner": "0.11.1",
+        "@washingtonpost/wpds-alert-banner": "0.11.2",
         "@washingtonpost/wpds-app-bar": "0.11.1",
         "@washingtonpost/wpds-avatar": "0.11.1",
         "@washingtonpost/wpds-box": "0.11.1",
-        "@washingtonpost/wpds-button": "0.11.1",
-        "@washingtonpost/wpds-checkbox": "0.11.1",
+        "@washingtonpost/wpds-button": "0.11.2",
+        "@washingtonpost/wpds-checkbox": "0.11.2",
         "@washingtonpost/wpds-container": "0.11.1",
         "@washingtonpost/wpds-divider": "0.11.1",
         "@washingtonpost/wpds-error-message": "0.11.1",
         "@washingtonpost/wpds-fieldset": "0.11.1",
         "@washingtonpost/wpds-helper-text": "0.11.1",
-        "@washingtonpost/wpds-icon": "0.11.1",
+        "@washingtonpost/wpds-icon": "0.11.2",
         "@washingtonpost/wpds-input-label": "0.11.1",
-        "@washingtonpost/wpds-input-password": "0.11.1",
+        "@washingtonpost/wpds-input-password": "0.11.2",
         "@washingtonpost/wpds-input-shared": "0.11.1",
-        "@washingtonpost/wpds-input-text": "0.11.1",
+        "@washingtonpost/wpds-input-text": "0.11.2",
         "@washingtonpost/wpds-input-textarea": "0.11.1",
         "@washingtonpost/wpds-radio-group": "0.11.1",
         "@washingtonpost/wpds-theme": "0.11.1",
-        "@washingtonpost/wpds-visually-hidden": "0.11.1"
+        "@washingtonpost/wpds-visually-hidden": "0.11.2"
       }
     },
     "@washingtonpost/wpds-visually-hidden": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-visually-hidden/-/wpds-visually-hidden-0.11.1.tgz",
-      "integrity": "sha512-f9+ShTsNZzTgCRhXAIgUQOBmozLR6p+xZF/FE+cOSUwoby7cMNtYWIPhqaF+ymAExUti+9Lr3xWH0w2ZOn4how==",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-visually-hidden/-/wpds-visually-hidden-0.11.2.tgz",
+      "integrity": "sha512-F/zdws5xHp9e7whwfVuAEqqWU0MD3JPTXEsTF/pNQ+aEIHA1ZBblr2C8MxGNMoVn/OIxcizVMjiYxGN5pMWEkw==",
       "requires": {
         "@washingtonpost/wpds-theme": "0.11.1",
         "react": "^16.8.6 || ^17.0.2"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@washingtonpost/site-footer": "latest",
     "@washingtonpost/site-third-party-scripts": "latest",
     "@washingtonpost/wpds-assets": "v1.8.0",
-    "@washingtonpost/wpds-ui-kit": "v0.11.1",
+    "@washingtonpost/wpds-ui-kit": "^0.11.2",
     "gray-matter": "^4.0.2",
     "lz-string": "^1.4.4",
     "next": "^12.1.0",


### PR DESCRIPTION
Examples updated under 'Guidance' section https://wpds-docs-git-update-checkbox-documentation.preview.now.washingtonpost.com/components/checkbox#Guidance 